### PR TITLE
get_materials to property

### DIFF
--- a/SEAT/Serpent2InputWriter/composition.py
+++ b/SEAT/Serpent2InputWriter/composition.py
@@ -188,7 +188,7 @@ class MaterialComposition:
         Parameters
         ----------
         abundance : dict[str, float]
-            * key: the symbol of the nuclides (`'Nn###'`) or elements (`''Nn`)
+            * key: the symbol of the nuclides (`'Nn###'`) or elements (`'Nn'`)
                     in the reference material.
             * value: the abundance of each nuclide or element.
         enrichers : dict[str, float]
@@ -900,6 +900,10 @@ class Material(Entity):
             kind = 'tft'
             number += 1
         string = "More than one temperature type" if number > 1 else "No temperature type"
+        # Actually, if number == 0, no temperature specificatio was given, which
+        # is allowed in Serpent. One could then think of unifying get_temperature
+        # and get_temperature_kind in format_temperature, which would return a
+        # string with kind and temperature or empty if no kind is given.
         if number != 1:
             raise Exception(string + f' was given to Material {self.name}')
         return kind

--- a/SEAT/Serpent2InputWriter/geometry.py
+++ b/SEAT/Serpent2InputWriter/geometry.py
@@ -265,7 +265,18 @@ class Surface(Entity):
         the input parameters required by the type expressed by `kind`. The
         default is {}.
     kind : str, optional
-        identifies the surface type. The default is 'sqc'.
+        identifies the surface type.
+        Allowed `kind` values are:
+            - 'cyl': z-cylinder.
+            - 'cylx': x-cylinder.
+            - 'cyly': y-cylinder.
+            - 'cylz': z-cylinder.
+            - 'plane': custom plane (equation or 3 points).
+            - 'px': x-perpendicular plane.
+            	- 'py': y-perpendicular plane.
+            - 'pz': x-perpendicular plane.
+            - 'sqc': squared cylinder.
+        The default is 'sqc'.
     _operator: str, optional
         the surface oprator. The default is ''.
 
@@ -350,7 +361,8 @@ class Cell(Entity):
         identifies the cell type.
         Allowed `kind` values are:
             - 'fill': to fill the cell with a universe.
-            - 'material': to fill the cell with a material; requires passing material to the Cell.
+            - 'material': to fill the cell with a material; requires passing
+                        material to the Cell.
             - 'outside': to define outside cells.
         The default is 'outside'.
     filler : `SEAT.Universe`

--- a/SEAT/Serpent2InputWriter/geometry.py
+++ b/SEAT/Serpent2InputWriter/geometry.py
@@ -56,8 +56,6 @@ class Universe(Entity):
         prints the `SEAT.Universe` python id.
     write :
         writes the `SEAT.Universe` to a file.
-    get_materials :
-        lists the materials in the Universe.
 
     """
     _materials: list[Material] = field(default_factory=list[Material])
@@ -122,8 +120,6 @@ class NestedUniverse(Universe):
         prints the `SEAT.NestedUniverse` python id.
     write :
         writes the `SEAT.NestedUniverse` to a file.
-    get_materials :
-        lists with the materials in the universe.
     nest_universe :
         adds a Universe-like object to the nested universe.
 
@@ -209,8 +205,6 @@ class Pin(Universe):
         prints the `SEAT.Pin` python id.
     write :
         writes the `SEAT.Pin` to a file.
-    get_materials :
-        lists the materials in the Pin.
 
     Class methods:
     --------------
@@ -394,8 +388,6 @@ class Cell(Entity):
         prints the `SEAT.Entity` python id.
     write :
         writes the `SEAT.Entity` to a file.
-    get_materials :
-        lists the materials in the Cell.
     _nest_to_father :
         nest the Cell to the father nested universe.
 
@@ -682,8 +674,6 @@ class Lattice(NestedUniverse):
         prints the `SEAT.Lattice` python id.
     write :
         writes the `SEAT.Lattice` to a file.
-    get_materials :
-        lists with the materials in the universe.
     nest_universe :
         adds a Universe-like object to the nested universe.
 

--- a/SEAT/Serpent2InputWriter/geometry.py
+++ b/SEAT/Serpent2InputWriter/geometry.py
@@ -151,7 +151,7 @@ class NestedUniverse(Universe):
         out = []
         for uni in self:
             out.extend(uni.materials)
-        return out
+        return out if out != [] else [None]
 
     def nest_universe(self, uni: Universe):
         """
@@ -254,7 +254,8 @@ class Pin(Universe):
         Called iteratively in the nested universes.
 
         """
-        return [t[0] for t in self.radi]
+        out = [t[0] for t in self.radi]
+        return out if out != [] else [None]
 
 
 @dataclass(slots=True)
@@ -725,7 +726,7 @@ class Lattice(NestedUniverse):
         out = []
         for uni in self:
             out.extend(uni.materials)
-        return out
+        return out if out != [] else [None]
 
 
 @dataclass(slots=True)

--- a/SEAT/Serpent2InputWriter/geometry.py
+++ b/SEAT/Serpent2InputWriter/geometry.py
@@ -437,11 +437,11 @@ class Cell(Entity):
             try:
                 UniversesIncluded[self.father.name].nest_universe(
                     Universe(name=f'{self.father.name}.{self.material.name}',
-                             materials=[self.material]))
+                             _materials=[self.material]))
             except ExistingUniverse:
                 UniversesIncluded[self.father.name].nest_universe(
                     Universe(name=f'{self.father.name}.{self.material.name}{sub_universe_number}',
-                             materials=[self.material]))
+                             _materials=[self.material]))
         else:  # is the exception needed here as well?
             UniversesIncluded[self.father.name].nest_universe(Universe(name=f'{self.father.name}.{None}'))
 

--- a/SEAT/Serpent2InputWriter/input.py
+++ b/SEAT/Serpent2InputWriter/input.py
@@ -676,7 +676,7 @@ class Simulation:
         strings = []
         divisions = []
         for lat in self.geometry.lattices:
-            for mat in lat.get_materials():
+            for mat in lat.materials:
                 if mat is not None and mat.division_string != '':
                     strings.append(mat.division_string)
                     divisions.extend(mat.divisions)

--- a/SEAT/surface_functions.py
+++ b/SEAT/surface_functions.py
@@ -6,7 +6,7 @@ Created on Tue Feb  7 14:11:04 2023
 """
 # from SEAT.Serpent2InputWriter import reformat
 
-def p_params(offset: float) -> str:
+def _p_params(offset: float) -> str:
     """
     Formats the parameters for a plane surface.
 
@@ -38,7 +38,7 @@ def px_params(x: float) -> str:
         the ordered parameters as Serpent2 formatted string.
 
     """
-    return p_params(x)
+    return _p_params(x)
 
 def py_params(y: float) -> str:
     """
@@ -55,7 +55,7 @@ def py_params(y: float) -> str:
         the ordered parameters as Serpent2 formatted string.
 
     """
-    return p_params(y)
+    return _p_params(y)
 
 def pz_params(z: float) -> str:
     """
@@ -72,7 +72,7 @@ def pz_params(z: float) -> str:
         the ordered parameters as Serpent2 formatted string.
 
     """
-    return p_params(z)
+    return _p_params(z)
 
 def plane_params(A: float=None, B: float=None, C: float=None, D: float=None,
                  c1: tuple[float]=None, c2: tuple[float]=None, c3: tuple[float]=None) -> str:

--- a/tests/test_Serpent2InputWriter/test_Geometry.py
+++ b/tests/test_Serpent2InputWriter/test_Geometry.py
@@ -165,7 +165,7 @@ class Test_LatticeRepresentation:
 
 
 class Test_Lattice:
-    simple_universe = geometry.Universe(name=UniverseNames.SUB_UNIVERSE, materials=[TEST_MATERIAL],
+    simple_universe = geometry.Universe(name=UniverseNames.SUB_UNIVERSE, _materials=[TEST_MATERIAL],
                                         comment=TEST_COMMENT)
     REPRESENTATION = geometry.LatticeRepresentation.from_rows([simple_universe, simple_universe], 2)
 

--- a/tests/test_Serpent2InputWriter/test_Geometry.py
+++ b/tests/test_Serpent2InputWriter/test_Geometry.py
@@ -23,8 +23,8 @@ class Test_Universe:
     def test_str(self) -> None:
         assert self.uni.__str__() == TEST_COMMENT.__str__() + UniverseNames.UNIVERSE
 
-    def test_get_materials(self) -> None:
-        assert self.uni.get_materials() == [None]
+    def test_materials(self) -> None:
+        assert self.uni.materials == [None]
 
 
 class Test_NestedUniverse:
@@ -33,8 +33,8 @@ class Test_NestedUniverse:
     def test_str(self) -> None:
         assert self.uni.__str__() == TEST_COMMENT.__str__() + UniverseNames.NESTED_UNIVERSE
 
-    def test_get_materials(self) -> None:
-        assert self.uni.get_materials() == []
+    def test_materials(self) -> None:
+        assert self.uni.materials == [None]
 
     def test_nest_universe(self) -> None:
         extra_universe = geometry.Universe(name="Extra")
@@ -106,8 +106,8 @@ class Test_Pin:
     def test_str(self) -> None:
         assert self.pin.__str__() == self.TEST_PIN_STRING
 
-    def test_get_materials(self) -> None:
-        assert self.pin.get_materials() == [self.mat1, self.mat2, self.mat3]
+    def test_materials(self) -> None:
+        assert self.pin.materials == [self.mat1, self.mat2, self.mat3]
 
     def test_radi_kwarg(self) -> None:
         pin_ = geometry.Pin(name=UniverseNames.PIN + '_', comment=TEST_COMMENT,
@@ -192,9 +192,9 @@ class Test_Lattice:
         assert np.alltrue(lattice.sub_universes == np.array([self.simple_universe] * 4))
         assert (lattice.sub_universes == np.array([self.simple_universe] * 4)).all()
 
-    def test_get_materials(self) -> None:
+    def test_materials(self) -> None:
         lattice = geometry.Lattice(name=UniverseNames.LATTICE2, representation=self.REPRESENTATION)
-        assert (lattice.get_materials() == np.array([TEST_MATERIAL] * 4)).all()
+        assert (lattice.materials == np.array([TEST_MATERIAL] * 4)).all()
 
 
 class Test_Geometry:

--- a/tests/test_SurfaceFunctions.py
+++ b/tests/test_SurfaceFunctions.py
@@ -10,16 +10,16 @@ import SEAT.surface_functions as sf
 class TestFunctions:
     A, B, C, D, E, F, G, H, I = range(9)
     def test_p_params(self):
-        assert sf.p_params(self.A) == '0'
+        assert sf._p_params(self.A) == '0'
 
     def test_px_params(self):
-        assert sf.p_params(self.A) == '0'
+        assert sf.px_params(self.A) == '0'
 
     def test_py_params(self):
-        assert sf.p_params(self.A) == '0'
+        assert sf.py_params(self.A) == '0'
 
     def test_pz_params(self):
-        assert sf.p_params(self.A) == '0'
+        assert sf.pz_params(self.A) == '0'
 
     def test_plane_params_equaiton(self):
         assert sf.plane_params(self.A, self.B, self.C, self.D) == '0 1 2 3'


### PR DESCRIPTION
* `Universe.get_material()` method was refactored to be a property.
This was updated through the whole geometry module.
* `NestedUniverse.materials` now returns `[None]` if no material is included.
* `Simulation.divisions()` was adapted to the changes.
* The `Test_Geometry` module was adapted to the changes.