### PR TITLE
division string refactor

### DIFF
--- a/SEAT/Serpent2InputWriter/composition.py
+++ b/SEAT/Serpent2InputWriter/composition.py
@@ -794,7 +794,7 @@ class Material(Entity):
             string += f"mix {self.name}" + self.inline_comment.__str__() + f"{self._mixture}"
         else:
             string += f"mat {self.name} {self.dens} "
-            string += "{self.temperature_kind} {self.temperature}" if self.temperature_kind != '' else ''
+            string += f"{self.temperature_kind} {self.temperature}" if self.temperature_kind != '' else ''
         # Check which cards work for the mix material and relate it to the transfer of kwargs in its definition
         if self.rgb is not None:
             string += f" rgb {self.rgb[0]} {self.rgb[1]} {self.rgb[2]}"

--- a/SEAT/Serpent2InputWriter/depletion.py
+++ b/SEAT/Serpent2InputWriter/depletion.py
@@ -115,7 +115,7 @@ class Interval:
     """
     span: float
     total: bool = False
-    span_type: str = 'day'
+    kind: str = 'day'
 
     @property
     def step(self) -> str:
@@ -132,7 +132,7 @@ class Interval:
         return step_
 
     def __str__(self):
-        string = f"dep {self.span_type}{self.step} {self.span}\n"
+        string = f"dep {self.kind}{self.step} {self.span}\n"
         return string
 
     def write(self, file: str, mode: str='a'):

--- a/SEAT/Serpent2InputWriter/geometry.py
+++ b/SEAT/Serpent2InputWriter/geometry.py
@@ -59,8 +59,8 @@ class Universe(Entity):
     _materials : list[`SEAT.Material`], optional
         the materials in the universe. The default is [].
 
-    Properties:
-    -----------
+    Properties
+    ----------
     materials : list[`SEAT.Material`] | [None]
         the materials in the universe. [None] if no material is included.
 
@@ -123,8 +123,8 @@ class NestedUniverse(Universe):
     daughters : list[Universe], optional
         the universes nested in the universe.
 
-    Properties:
-    -----------
+    Properties
+    ----------
     materials : list[`SEAT.Material`] | [None]
         the materials in the universe. [None] if no material is included.
 
@@ -208,13 +208,13 @@ class Pin(Universe):
         couples the Material and its radius (0 or `None` for external material).
         The default is [].
 
-    Properties:
-    -----------
+    Properties
+    ----------
     materials : list[`SEAT.Material`] | [None]
         the materials in the universe. [None] if no material is included.
 
-    Methods:
-    --------
+    Methods
+    -------
     assess :
         prints the `SEAT.Pin` python id.
     write :
@@ -481,8 +481,8 @@ class CellWrap(Universe):
     _cells : list[`SEAT.Cell`], optional
         the list of cells wrapepd in the father universe. The default is [].
 
-    Properties:
-    -----------
+    Properties
+    ----------
     materials : list[`SEAT.Material`] | [None]
         the materials in the universe. [None] if no material is included.
     cells : list[`SEAT.Cell`]
@@ -591,9 +591,9 @@ class LatticeRepresentation:
 
     Properties
     ----------
-    as_array :
+    as_array : `np.ndarray`
         the representation universes as `np.ndarray`.
-    flatten :
+    flatten : `np.ndarray`
         the represenattion universe as 1D `np.array`.
 
     Methods

--- a/SEAT/Serpent2InputWriter/input.py
+++ b/SEAT/Serpent2InputWriter/input.py
@@ -677,7 +677,7 @@ class Simulation:
         divisions = []
         for lat in self.geometry.lattices:
             for mat in lat.materials:
-                if mat is not None and mat.division_string != '':
-                    strings.append(mat.division_string)
+                if mat is not None and mat._division_string != '':
+                    strings.append(mat._division_string)
                     divisions.extend(mat.divisions)
         return DivisionWriter(strings, DivisionWrapper(divisions))

--- a/tests/test_Serpent2InputWriter/test_Composition.py
+++ b/tests/test_Serpent2InputWriter/test_Composition.py
@@ -199,18 +199,18 @@ class Test_Material:
         mat = composition.Material.mix(name=TEST_NAME, materials=[(mat1, c1), (mat2, c2)])
         assert mat.__str__() == f"""mix {TEST_NAME}\n{mat1.name} {c1}\n{mat2.name} {c2}\n\n\n"""
 
-    def test_get_temperature(self) -> None:
+    def test_temperature(self) -> None:
         mat = composition.Material(name=TEST_NAME, tms=self.TEMPERATURE)
-        assert mat.get_temperature() == str(self.TEMPERATURE)
+        assert mat.temperature == str(self.TEMPERATURE)
         mat = composition.Material(name=TEST_NAME, tmp=self.TEMPERATURE)
-        assert mat.get_temperature() == str(self.TEMPERATURE)
+        assert mat.temperature == str(self.TEMPERATURE)
         mat = composition.Material(name=TEST_NAME, tft=(self.TEMPERATURE, self.TEMPERATURE))
-        assert mat.get_temperature() == f'{self.TEMPERATURE} {self.TEMPERATURE}'
+        assert mat.temperature == f'{self.TEMPERATURE} {self.TEMPERATURE}'
 
-    def test_get_temperature_kind(self) -> None:
+    def test_temperature_kind(self) -> None:
         mat = composition.Material(name=TEST_NAME, dens=self.DENSITY, representation=self.REPRESENTATION, burn=True,
                                    tft=(self.TEMPERATURE, self.TEMPERATURE))
-        assert mat.get_temperature_kind() == 'tft'
+        assert mat.temperature_kind == 'tft'
 
     def test_divide(self) -> None:
         pass

--- a/tests/test_Serpent2InputWriter/test_Depletion.py
+++ b/tests/test_Serpent2InputWriter/test_Depletion.py
@@ -13,7 +13,7 @@ class Test_Interval:
         assert self.interval.step == 'step'
 
     def test_str(self) -> None:
-        assert self.interval.__str__() == f'dep {self.interval.span_type}{self.interval.step} {self.interval.span}\n'
+        assert self.interval.__str__() == f'dep {self.interval.kind}{self.interval.step} {self.interval.span}\n'
 
 
 class Test_Normalisation:


### PR DESCRIPTION
Fixing a bug on the internal use of `SEAT.Material._division_string`