### PR TITLE
Hashabilty and duplicability

### DIFF
--- a/SEAT/Serpent2InputWriter/base.py
+++ b/SEAT/Serpent2InputWriter/base.py
@@ -291,11 +291,15 @@ class Entity:
     ----------
     name : str | int
         the identity of the Serpent 2 entity.
+        SHOULD NOT BE MODIFIED AFTER INITIALIZATION.
     comment : `SEAT.Comment`, optional
         the comment to the Serpent entity. The default is SEAT.Comment('').
     inline_comment : `SEAT.InlineComment`, optional
         the comment to be written on the same line as the Serpent 2 entity id.
         The default is SEAT.Comment('').
+    _hashable_name : None
+        the hashable name for the entity hash. The default is None; then it is
+        initialized to `_Immutable(self.name)` in the `__post_init__` method
 
     Methods
     --------
@@ -306,11 +310,16 @@ class Entity:
     duplicate :
         makes a superficial copy of the `SEAT.Entity` with a new name.
 
+    Note
+    ----
+    `name` and `_hashable_name` should not be changed. Consider using the 
+    `duplicate` method to get similar results.
+
     """
     name: str | int  # **NEVER** change; use self.duplicate() instead
     comment: Comment = Comment('')
     inline_comment: InlineComment = InlineComment('')
-    _hashable_name: str | int = None  # This is private for good reasons
+    _hashable_name: None = None  # This is private for good reasons
 
     def __post_init__(self):
         self._hashable_name = _Immutable(self.name)

--- a/tests/test_Serpent2InputWriter/test_Base.py
+++ b/tests/test_Serpent2InputWriter/test_Base.py
@@ -33,13 +33,26 @@ class Test_InlineComment:
 
 
 class Test_Entity:
+    entity = base.Entity(name=TEST_NAME)
+
     def test_str(self) -> None:
-        entity = base.Entity(name=TEST_NAME)
-        assert entity.__str__() == TEST_NAME
+        assert self.entity.__str__() == TEST_NAME
 
     def test_numerical_name(self):
         entity = base.Entity(name=1)
         assert entity.__str__() == '1'
+
+    def test_hashable_name(self):
+        assert self.entity._hashable_name == base._Immutable(TEST_NAME)
+
+    def test_hashability(self):
+        assert {self.entity}
+
+    def test_duplicate(self):
+        entity = self.entity.duplicate(TEST_NAME + "_")
+        for attr in entity.__slots__:
+            if "name" not in attr:
+                assert getattr(entity, attr) is getattr(self.entity, attr)
 
 
 class Test_Functions:


### PR DESCRIPTION
The `SEAT.Entity` is now provided with `__eq__` and `__hash__` methods.
To do so, a new frozen class was implemented (`base._Immutable`). `SEAT.Entity._hashable_name` was then defined to be an instance of the new class.

`SEAT.Entity` was also provided with a `duplicate` method to allow safe name changes.